### PR TITLE
Potential fix for code scanning alert no. 28: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,4 +1,4 @@
-import json
+
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple


### PR DESCRIPTION
Potential fix for [https://github.com/lxnnxs/cronk-aula/security/code-scanning/28](https://github.com/lxnnxs/cronk-aula/security/code-scanning/28)

To fix the problem, we need to remove the unused import statement for the `json` module. This will make the code cleaner and eliminate the unnecessary dependency. The change should be made in the file `src/cronk/cron_to_json.py` by deleting the line that imports the `json` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
