### PR TITLE
Potential fix for code scanning alert no. 29: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,6 +1,6 @@
 import json
 import re
-from dataclasses import dataclass, field
+
 from typing import Dict, List, Tuple
 
 from loguru import logger


### PR DESCRIPTION
Potential fix for [https://github.com/lxnnxs/cronk-aula/security/code-scanning/29](https://github.com/lxnnxs/cronk-aula/security/code-scanning/29)

To fix the problem, we need to remove the unused imports from the code. Specifically, we should delete the line that imports `dataclass` and `field` from the `dataclasses` module. This will clean up the code and remove unnecessary dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
